### PR TITLE
Add agreed upon Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,29 @@
+# The `Corvid` Code of Professional Conduct
+
+The `Corvid` Code of Professional Conduct is licensed under the [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) license.
+
+This Code of Professional Conduct is heavily modeled on the [`Winnie_Bot`](https://github.com/aigeroni/Winnie_Bot) [Code of Professional Conduct](https://github.com/aigeroni/Winnie_Bot/blob/main-2.0/CODE_OF_CONDUCT.md) (also licensed under the [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) license).
+
+The `Corvid` initiative includes contributors from around the world, volunteering their time and expertise to support this valuable open-source project. Many of these contributors identify with historically marginalized communities or have experienced significant trauma in their personal lives. For that reason, a clear and enforced code of conduct is essential to ensure that all volunteers participate with dignity and that the work unfolds without causing personal harm or delaying the progress of the project.
+
+The goal of this framework isn't to suppress speech. All contributors, regardless of their individual beliefs and experiences, are and should be free to express themselves openly. However, a person's beliefs and experiences are not a source of debate or discussion -- at least, not in a space that's focused on enhancements to open-source software. To ensure that we can make Corvid an excellent bot, it's helpful to set ground rules for people participating in the rewrite project.
+
+## Ground Rules
+
+Please observe the following conduct standards while participating in this project:
+
+1. **Don't be a dick.** In a text-heavy social environment where people may lack deep personal familiarity, sarcasm and venting may not be received in the spirit in which they were offered. Aim for communication that's friendly and avoids boundary-crossing, negativity, one-upsmanship, or intrusion into personal space. Professionalism is essential for happy and productive relationships!
+2. **Avoid contentious topics within the public team space.** We do not expect people to downplay their demographic attributes, philosophical positions, or personal identities. We realize, however, that in a diverse group, these traits can be like dry tinder awaiting a spark. Therefore, discussion of contentious topics (politics, race, sex, gender, religion, psychology, etc.) should be reserved to private messages only, away from the public team space.
+3. **Respect the personhood of others.** People are who they say they are. Please identify others as they wish to be identified. Part of identity includes the varied experiences -- good and bad -- we each accumulate on our life's journey. Remain sensitive to people who may struggle with physical, emotional, or spiritual challenges or who may have suffered trauma in their lives. For example, if a person says they can't do, require assistance to do or need more time to do [a thing] because of [a reason]; accept that statement at face value. It's not an invitation to offer unsolicited advice or counseling, or to probe at that person's life history.
+4. **Front-channel everything.** Raise all questions, comments, or concerns in the relevant Discord conversation. We value transparency, and a transparent community thrives when all communication -- even the hard stuff -- is aired in broad daylight. Please refrain from engaging in private back-channel communication, even for seemingly minor things like clarifications, because it's likely that others may be interested in the response. More eyeballs on questions makes for fewer errors in the long run.
+5. **Observe the `Corvid` Code of Conduct while testing or coding the product.** Unless you're deliberately testing programmatic content filters as part of a defined/approved task, avoid inserting sarcastic, obscene, or insensitive language into the code (even as comments or placeholders) or into the titles of test challenges or projects. All public-facing language must be appropriate for audiences of every age level and life history.
+
+## Conduct Violations
+
+The `Corvid` team consists of volunteers working primarily asynchronously and by text. It's therefore inevitable that misunderstandings will occasionally arise. People who believe they've observed a violation of these ground rules are encouraged to raise the matter with a Development Leader. People who are not party to a potential violation are discouraged from acting as the "enforcement police" by intervening on their own. If you are on the receiving end of inappropriate conduct, you are welcome to approach the transgressor personally if you are comfortable doing so. If you aren't, then please seek support from the appropriate project leader. It is better to raise a concern that opens the door to an amicable resolution than to suffer in silence and thereby engender mistrust and toxicity that proves more challenging to address as time and ill will accumulate.
+
+A person who appears to have broken a conduct standard will be approached by a Development Leader to discuss the situation and its optimal remediation. In our experience with other projects, it's usually the case that a friendly private chat proves sufficient to educate the team member.
+
+If, however, a person continues to behave in an inappropriate fashion, that person will be removed from the project entirely. To promote full transparency, the relevant leader will announce the decision and its rationale to the entire project team.
+
+[Back to README](./README.md)


### PR DESCRIPTION
Copies the Code of Conduct found in the github wiki for this project into its own file at the root of the repository. Once this pull request is approved and merged, the wiki can (and should) be updated to point to the CODE_OF_CONDUCT.md file instead.